### PR TITLE
feat: Add full Plex track import and coverage metrics for artists and…

### DIFF
--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.marcal.mediapulse.server"
-version = "0.1.4-beta"
+version = "0.1.5-beta"
 
 java {
     toolchain {

--- a/server/src/main/kotlin/dev/marcal/mediapulse/server/api/music/CoverageResponses.kt
+++ b/server/src/main/kotlin/dev/marcal/mediapulse/server/api/music/CoverageResponses.kt
@@ -1,0 +1,19 @@
+package dev.marcal.mediapulse.server.api.music
+
+data class ArtistCoverageResponse(
+    val artistId: Long,
+    val artistName: String,
+    val totalTracks: Long,
+    val playedTracks: Long,
+    val coveragePercent: Double,
+)
+
+data class AlbumCoverageResponse(
+    val albumId: Long,
+    val artistId: Long,
+    val albumTitle: String,
+    val artistName: String,
+    val totalTracks: Long,
+    val playedTracks: Long,
+    val coveragePercent: Double,
+)

--- a/server/src/main/kotlin/dev/marcal/mediapulse/server/controller/music/MusicSummaryController.kt
+++ b/server/src/main/kotlin/dev/marcal/mediapulse/server/controller/music/MusicSummaryController.kt
@@ -64,6 +64,16 @@ class MusicSummaryController(
         @RequestParam(defaultValue = "50") limit: Int,
     ) = repository.getNeverPlayedAlbums(limit)
 
+    @GetMapping("/coverage/artists")
+    fun artistCoverage(
+        @RequestParam(defaultValue = "50") limit: Int,
+    ) = repository.getArtistCoverage(limit)
+
+    @GetMapping("/coverage/albums")
+    fun albumCoverage(
+        @RequestParam(defaultValue = "50") limit: Int,
+    ) = repository.getAlbumCoverage(limit)
+
     @GetMapping("/search")
     fun search(
         @RequestParam q: String,

--- a/server/src/main/kotlin/dev/marcal/mediapulse/server/controller/music/music.http
+++ b/server/src/main/kotlin/dev/marcal/mediapulse/server/controller/music/music.http
@@ -84,3 +84,11 @@ Accept: application/json
 ### Busca álbuns nunca ouvidos, limit default=50
 GET {{baseUrl}}/albums/never-played?limit=50
 Accept: application/json
+
+### Busca o quanto já ouviu dos albums
+GET {{baseUrl}}/coverage/albums?limit=50
+Accept: application/json
+
+### Busca o quanto já ouviu dos artitas
+GET {{baseUrl}}/coverage/artists?limit=50
+Accept: application/json

--- a/server/src/main/kotlin/dev/marcal/mediapulse/server/integration/plex/dto/PlexContainer.kt
+++ b/server/src/main/kotlin/dev/marcal/mediapulse/server/integration/plex/dto/PlexContainer.kt
@@ -38,3 +38,14 @@ data class PlexAlbum(
     val thumb: String? = null,
     @JsonProperty("Guid") val guids: List<PlexGuid>? = emptyList(),
 )
+
+data class PlexTrack(
+    val ratingKey: String,
+    val parentRatingKey: String? = null, // álbum
+    val grandparentRatingKey: String? = null, // artista
+    val title: String,
+    val index: Int? = null, // trackNumber
+    val parentIndex: Int? = null, // discNumber
+    val duration: Long? = null, // em ms, se vier
+    @JsonProperty("Guid") val guids: List<PlexGuid>? = emptyList(),
+)

--- a/server/src/main/kotlin/dev/marcal/mediapulse/server/service/plex/import/PlexImportScheduler.kt
+++ b/server/src/main/kotlin/dev/marcal/mediapulse/server/service/plex/import/PlexImportScheduler.kt
@@ -28,7 +28,9 @@ class PlexImportScheduler(
                     plexImportService.importAllArtistsAndAlbums(
                         pageSize = plexProps.import.pageSize,
                     )
-                logger.info("Plex scheduled import done. artistsSeen=${stats.artistsSeen}, albumsSeen=${stats.albumsSeen}")
+                logger.info(
+                    "Plex scheduled import done. artistsSeen=${stats.artistsSeen}, albumsSeen=${stats.albumsSeen}, tracksSeen=${stats.tracksSeen}",
+                )
             } catch (e: Exception) {
                 logger.error("Error running Plex scheduled import", e)
             }

--- a/server/src/main/kotlin/dev/marcal/mediapulse/server/service/plex/import/PlexStartupImporter.kt
+++ b/server/src/main/kotlin/dev/marcal/mediapulse/server/service/plex/import/PlexStartupImporter.kt
@@ -30,7 +30,9 @@ class PlexStartupImporter(
                     plexImportService.importAllArtistsAndAlbums(
                         pageSize = plexProps.import.pageSize,
                     )
-                logger.info("Plex initial import done. artistsSeen=${stats.artistsSeen}, albumsSeen=${stats.albumsSeen}")
+                logger.info(
+                    "Plex initial import done. artistsSeen=${stats.artistsSeen}, albumsSeen=${stats.albumsSeen}, tracksSeen=${stats.tracksSeen}",
+                )
             } catch (e: Exception) {
                 logger.error("Error running Plex initial import", e)
             }


### PR DESCRIPTION
… albums

- Implement Plex track listing (type=10) and import per album
- Add ArtistCoverageResponse and AlbumCoverageResponse DTOs
- Add endpoints for coverage reporting in MusicSummaryController
- Implement repository queries for artist and album coverage
- Extend import stats and logs to include track counts
- Update HTTP client examples and scheduler logs